### PR TITLE
Fixed incorrect import

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "vendor/golang.org/x/crypto"]
 	path = vendor/golang.org/x/crypto
 	url = https://go.googlesource.com/crypto
-[submodule "vendor/github.com/alecthomas/kingpen"]
-	path = vendor/github.com/alecthomas/kingpen
+[submodule "vendor/github.com/alecthomas/kingpin"]
+	path = vendor/github.com/alecthomas/kingpin
 	url = https://github.com/alecthomas/kingpin.git
 [submodule "vendor/github.com/alecthomas/template"]
 	path = vendor/github.com/alecthomas/template

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/alecthomas/kingpen"
+	"github.com/alecthomas/kingpin"
 	"golang.org/x/crypto/ssh/terminal"
 
 	crypt "github.com/evantbyrne/crypt/lib"


### PR DESCRIPTION
The kingpin module was incorrectly named kingpen in this project.
This resolves evantbyrne/crypt#1.

Renamed vendored kingpen to kingpin

The vendored repo was named incorrectly.

Fixed bad import name

The kingpin import was incorrectly named kingpen. This has been
corrected.
