### PR TITLE
Changed default mode of created files

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 		if *outFlag == "" {
 			fmt.Printf("%s\n", out)
 		} else {
-			err = ioutil.WriteFile(*outFlag, out, 0644)
+			err = ioutil.WriteFile(*outFlag, out, 0600)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -74,7 +74,7 @@ func main() {
 		if *outFlag == "" {
 			fmt.Printf("%s\n", out)
 		} else {
-			err = ioutil.WriteFile(*outFlag, out, 0644)
+			err = ioutil.WriteFile(*outFlag, out, 0600)
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
The old mode was -rw-r--r--, I have modified it to -rw-------. This
should help keep information from being accidentally leaked.

e.g. Encrypting / Decrypting a large file -- one may decrypt or encrypt
to /tmp.

evantbyrne/crypt#8
